### PR TITLE
Fix another infinite loop

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -299,7 +299,7 @@ function usePersistentState<
     return () => {
       isMounted = false;
     };
-  }, [storageKey, defaultValue]);
+  }, [storageKey]);
 
   // Debounced save function
   const debouncedSave = useMemo(


### PR DESCRIPTION
`render() -> usePersistentState('typehere-deletedNotes',[]) -> loadInitialData() -> setData() -> render()`, or smth like that.

This time typehere is only at 86% sustained CPU, which is progress. Hopefully this fix will bring it to 0.